### PR TITLE
Add `rustfmt` to `components` argument of toolchain action

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,8 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: rustfmt
       - uses: mbrobbel/rustfmt-check@master
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
@@ -49,6 +51,8 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: dtolnay/rust-toolchain@nightly
+        with:
+          components: rustfmt
       - uses: mbrobbel/rustfmt-check@master
         with:
           token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Closes #850. 
Update instructions in `README` to include the `rustfmt` component as argument to the toolchain action.

bors r+